### PR TITLE
Cache connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ path = "tests/test.rs"
 
 [dependencies]
 r2d2 = "0.6"
-redis = "0.3.1"
+redis = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,11 +106,11 @@ impl r2d2::ManageConnection for RedisConnectionManager {
         //redis::Client::open(self.connection_info.clone()).map_err(Error::Other)
         // ...instead of having to do these 7 lines.
         let connection_info = redis::ConnectionInfo {
-            host: self.connection_info.host.clone(),
-            port: self.connection_info.port,
-            db: self.connection_info.db,
-            passwd: self.connection_info.passwd.clone(),
+            addr:    self.connection_info.addr.clone(),
+            db:      self.connection_info.db,
+            passwd:  self.connection_info.passwd.clone()
         };
+
         redis::Client::open(connection_info).map_err(Error::Other)
     }
 


### PR DESCRIPTION
The current implementation doesn't really do much besides caching a client instance, not the real connection.

This PR changes this and also switches to a newer Redis. If you want strict version numbers, I can change that.
