### PR TITLE
update r2d2 dependency to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ name = "test"
 path = "tests/test.rs"
 
 [dependencies]
-r2d2 = "0.6"
+r2d2 = "0.7"
 redis = "0.5"


### PR DESCRIPTION
This bumps the dependency on R2D2 to the latest which I've verified to be compatible with r2d2-redis
