### PR TITLE
Get rid of .unwrap() in Error::fmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,10 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}: {}", self.description(), self.cause().unwrap())
+        match self.cause() {
+            Some(cause) => write!(fmt, "{}: {}", self.description(), cause),
+            None => write!(fmt, "{}", self.description()),
+        }
     }
 }
 


### PR DESCRIPTION
This unwrap would bite me in case there is no cause in the error being reported.

Steps to reproduce:
- Start Redis
- Create and initialize connection pool (with error logging enabled)
- Stop Redis again
- Run `pool.get()`

The result is a panic.
