### PR TITLE
bump redis dep to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ path = "tests/test.rs"
 
 [dependencies]
 r2d2 = "0.7"
-redis = "0.6"
+redis = "0.7"


### PR DESCRIPTION
This bumps the Redis dependency to the latest minor version

Signed-off-by: Jamie Winsor jamie@vialstudios.com
