### PR TITLE
Bump Redis depencency to v0.7.1 (fixes Windows builds)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ path = "tests/test.rs"
 
 [dependencies]
 r2d2 = "0.7"
-redis = "0.7"
+redis = "0.7.1"


### PR DESCRIPTION
The redis v0.7.0 crate build is broken for systems without Unix socket support.