### PR TITLE
Update README.md so examples compile with newer redis-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ fn main() {
     for _i in 0..10i32 {
         let pool = pool.clone();
         handles.push(thread::spawn(move || {
-            let conn = pool.get().unwrap();
+            let mut conn = pool.get().unwrap();
             let n: i64 = conn.incr("counter", 1).unwrap();
             println!("Counter increased to {}", n);
         }));
@@ -70,7 +70,7 @@ Run with `cargo run --example ping`:
 ```rust
 extern crate r2d2_redis;
 
-use std::ops::Deref;
+use std::ops::DerefMut;
 use std::thread;
 
 use r2d2_redis::{r2d2, redis, RedisConnectionManager};
@@ -86,10 +86,10 @@ fn main() {
     for _i in 0..10i32 {
         let pool = pool.clone();
         handles.push(thread::spawn(move || {
-            let conn = pool.get().unwrap();
-            let reply = redis::cmd("PING").query::<String>(conn.deref()).unwrap();
+            let mut conn = pool.get().unwrap();
+            let reply = redis::cmd("PING").query::<String>(conn.deref_mut()).unwrap();
             // Alternatively, without deref():
-            // let reply = redis::cmd("PING").query::<String>(&*conn).unwrap();
+            // let reply = redis::cmd("PING").query::<String>(&mut *conn).unwrap();
             assert_eq!("PONG", reply);
         }));
     }


### PR DESCRIPTION
Just updates the README.md examples so they compile with the current redis-rs API.